### PR TITLE
Simpler particularization

### DIFF
--- a/src/sledge/__init__.py
+++ b/src/sledge/__init__.py
@@ -15,7 +15,8 @@ def particularize_descriptors(descriptors, particular_threshold=1.0):
         minimum_support = np.min(column)
         maximum_support = np.max(column)
 
-        toremove = column < minimum_support + particular_threshold * (maximum_support - minimum_support)
+        toremove = column < minimum_support + \
+            particular_threshold * (maximum_support - minimum_support)
         descriptors.loc[toremove, feature] = 0.0
 
     return descriptors
@@ -59,8 +60,8 @@ def semantic_descriptors(X, labels, particular_threshold=None):
     support = X.groupby(pd.Series(labels)).apply(np.mean)
 
     if particular_threshold is not None:
-        support = particularize_descriptors(support,
-                particular_threshold=particular_threshold)
+        support = particularize_descriptors(
+            support, particular_threshold=particular_threshold)
 
     return support
 
@@ -181,9 +182,12 @@ def sledge_score(X, labels, particular_threshold=None, aggregation='harmonic'):
         Average SLEDge score.
     """
     assert aggregation is not None
-    return np.mean(sledge_score_clusters(X, labels,
-                                         particular_threshold=particular_threshold,
-                                         aggregation=aggregation))
+    return np.mean(
+        sledge_score_clusters(
+            X,
+            labels,
+            particular_threshold=particular_threshold,
+            aggregation=aggregation))
 
 
 def sledge_curve(X, labels, particular_threshold=0.0, aggregation='harmonic'):
@@ -215,7 +219,7 @@ def sledge_curve(X, labels, particular_threshold=0.0, aggregation='harmonic'):
         always `1`.
     """
     scores = sledge_score_clusters(X, labels,
-            particular_threshold=particular_threshold,
+                                   particular_threshold=particular_threshold,
                                    aggregation=aggregation)
     n_clusters = len(scores)
 

--- a/src/sledge/__init__.py
+++ b/src/sledge/__init__.py
@@ -200,7 +200,7 @@ def sledge_curve(X, labels, minimum_support=0.0, aggregation='harmonic'):
     -------
     fractions: array-like of shape (>2,)
         Decreasing rate that element `i` is the fraction of clusters with
-        SLEDge score > `thresholds[i]`.  `fractions[0]` is always `1`.
+        SLEDge score >= `thresholds[i]`.  `fractions[0]` is always `1`.
     thresholds: array-like of shape (>2, )
         Increasing thresholds of the cluster SLEDge score used to compute
         `fractions`.  `thresholds[0]` is always `0` and `thresholds[-1]` is

--- a/tests/main.py
+++ b/tests/main.py
@@ -34,7 +34,7 @@ class TestSimpleCalculations(unittest.TestCase):
         descriptors = semantic_descriptors(X, labels)
 
         self.assertLess(0, np.max(descriptors.transpose()[0]))
-        self.assertEqual(0, np.max(descriptors.transpose()[1]))
+        self.assertLess(0, np.max(descriptors.transpose()[1]))
 
         score = sledge_score_clusters(X, labels)
         self.assertEqual(0, score[1])
@@ -56,14 +56,14 @@ class TestSimpleCalculations(unittest.TestCase):
         values = score_matrix.to_dict('records')
 
         self.assertLess(0, values[0]['S'])
-        self.assertEqual(1, values[0]['L'])
-        self.assertEqual(1, values[0]['E'])
+        self.assertLess(0, values[0]['L'])
+        self.assertLess(0, values[0]['E'])
         self.assertLess(0, values[0]['D'])
 
-        self.assertEqual(0, values[1]['S'])
-        self.assertEqual(0, values[1]['L'])
-        self.assertEqual(0, values[1]['E'])
-        self.assertEqual(0, values[1]['D'])
+        self.assertLessEqual(0, values[1]['S'])
+        self.assertLessEqual(0, values[1]['L'])
+        self.assertLessEqual(0, values[1]['E'])
+        self.assertLessEqual(0, values[1]['D'])
 
     def test_curve(self):
         X = pd.DataFrame.from_dict({
@@ -81,6 +81,21 @@ class TestSimpleCalculations(unittest.TestCase):
         self.assertEqual(1, thr[-1])
         self.assertEqual(1, frac[1])
 
+    def test_particularization(self):
+        X = pd.DataFrame.from_dict({
+            'A': [1, 0, 1, 0, 0, 0, 0, 0],
+            'B': [1, 0, 0, 0, 0, 0, 0, 1],
+            'C': [1, 1, 1, 1, 1, 1, 0, 0],
+            'D': [0, 0, 0, 1, 0, 1, 1, 0],
+            'E': [0, 0, 0, 1, 1, 0, 1, 0]})
+
+        labels = [0, 0, 0, 1, 1, 1, 1, 2]
+
+        score = sledge_score_clusters(X, labels, aggregation=None, particular_threshold=1)
+        values = score.to_dict('records')
+
+        for i in range(3):
+            self.assertEqual(1, values[i]['E'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/main.py
+++ b/tests/main.py
@@ -91,11 +91,13 @@ class TestSimpleCalculations(unittest.TestCase):
 
         labels = [0, 0, 0, 1, 1, 1, 1, 2]
 
-        score = sledge_score_clusters(X, labels, aggregation=None, particular_threshold=1)
+        score = sledge_score_clusters(
+            X, labels, aggregation=None, particular_threshold=1)
         values = score.to_dict('records')
 
         for i in range(3):
             self.assertEqual(1, values[i]['E'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The current particularization strategy uses a geometric mean between average and maximum values of support. Although it seems to be a reasonable strategy, it has no user control and it is hard to explain. Maybe this simpler strategy can be used instead in the first paper.

One advantage of this proposed alternative is that one can first maximize the SLEDge with `particular_threshold=None` (i.e. no particularization), and, afterward, adjust `particular_threshold`.

Another interesting property is that `particular_threshold=1` increases the chance of E=1 for all clusters. 