### PR TITLE
Update __init__.py

### DIFF
--- a/src/sledge/__init__.py
+++ b/src/sledge/__init__.py
@@ -91,7 +91,7 @@ def semantic_descriptors(X, labels, particular_threshold=None):
     features = X.columns
 
     # 1-itemsets, for greater k we need a different algorithm
-    support = X.groupby(labels).apply(np.mean)
+    support = X.groupby(labels).mean()
 
     if particular_threshold is not None:
         support = particularize_descriptors(


### PR DESCRIPTION
O pack tava apresentando esse erro sempre que calculava o SLEDge_score.

_FutureWarning: In a future version, DataFrame.mean(axis=None) will return a scalar mean over the entire DataFrame. To retain the old behavior, use 'frame.mean(axis=0)' or just 'frame.mean()'
  return mean(axis=axis, dtype=dtype, out=out, **kwargs)_